### PR TITLE
Make docs build cleanly and add links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,14 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+# on_rtd is whether we are on readthedocs.org, this line of code
+# grabbed from docs.readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,4 +3,15 @@
 leicacam API reference
 ==========================================
 
-.. include:: leicacam.rst
+- `Project source at GitHub`_
+- `Releases at PyPI`_
+
+.. _`Project source at GitHub`: https://github.com/arve0/leicacam
+.. _`Releases at PyPI`: https://pypi.org/project/leicacam/
+
+Contents:
+
+.. toctree::
+    :maxdepth: 2
+
+    leicacam

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-leicacam
-========
-
-.. toctree::
-   :maxdepth: 4
-
-   leicacam

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 Sphinx>=1.7.2
+sphinx_rtd_theme>=0.2.5b2

--- a/leicacam/cam.py
+++ b/leicacam/cam.py
@@ -63,7 +63,7 @@ class CAM(object):
     def send(self, commands):
         """Send commands to LASAF through CAM-socket.
 
-        Paramenters
+        Parameters
         -----------
         commands : list of tuples or bytes string
             Commands as a list of tuples or a bytes string. cam.prefix is

--- a/leicacam/cam.py
+++ b/leicacam/cam.py
@@ -64,7 +64,7 @@ class CAM(object):
         """Send commands to LASAF through CAM-socket.
 
         Parameters
-        -----------
+        ----------
         commands : list of tuples or bytes string
             Commands as a list of tuples or a bytes string. cam.prefix is
             allways prepended before sending.


### PR DESCRIPTION
* Fix docstring typo.
* Use RTD theme locally.
* Comment not used html static path setting to avoid build warning.
* Add links to github and pypi to docs index page.
* Remove modules.rst from docs source to avoid build warnings about duplicates.