### PR TITLE
Add decorator logger for pydebug

### DIFF
--- a/leicacam/cam.py
+++ b/leicacam/cam.py
@@ -20,7 +20,7 @@ def logger(function):
     def wrapper(*args, **kwargs):
         """Wrap function."""
         sep = kwargs.get('sep', ' ')
-        end = kwargs.get('end', '\n')
+        end = kwargs.get('end', '')  # do not add newline by default
         out = sep.join([repr(x) for x in args])
         out = out + end
         _LOGGER.debug(out)

--- a/leicacam/cam.py
+++ b/leicacam/cam.py
@@ -19,7 +19,11 @@ def logger(function):
     @functools.wraps(function)
     def wrapper(*args, **kwargs):
         """Wrap function."""
-        _LOGGER.debug(*args)
+        sep = kwargs.get('sep', ' ')
+        end = kwargs.get('end', '\n')
+        out = sep.join([repr(x) for x in args])
+        out = out + end
+        _LOGGER.debug(out)
         return function(*args, **kwargs)
     return wrapper
 

--- a/leicacam/cam.py
+++ b/leicacam/cam.py
@@ -2,6 +2,8 @@
 from __future__ import print_function
 
 import os
+import functools
+import logging
 import platform
 import socket
 from collections import OrderedDict
@@ -9,9 +11,23 @@ from time import sleep, time
 
 import pydebug
 
+_LOGGER = logging.getLogger(__name__)
+
+
+def logger(function):
+    """Decorate passed in function and log message to module logger."""
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        """Wrap function."""
+        _LOGGER.debug(*args)
+        return function(*args, **kwargs)
+    return wrapper
+
+
 # debug with `DEBUG=leicacam python script.py`
 if platform.system() == 'Windows':
     # monkeypatch
+    @logger
     def debug(msg):
         """Debug on Windows."""
         try:
@@ -21,7 +37,7 @@ if platform.system() == 'Windows':
         except KeyError:
             pass
 else:
-    debug = pydebug.debug('leicacam')  # pylint: disable=invalid-name
+    debug = logger(pydebug.debug('leicacam'))  # pylint: disable=invalid-name
 
 
 class CAM(object):


### PR DESCRIPTION
* Use decorator to pass the same messages to the debug log as is passed using the debug function to standard err.
* This will let users use python standard logging.
* Respect pydebug api and make output logging safe.
* Do not add newline by default.