### PR TITLE
Add asyncio support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+exclude_lines =
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError

--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ Control Leica microscopes with python
 
 ## Installation
 
-Install using `pip`...
+Install using `pip`:
 
 ```bash
 pip install leicacam
+```
+Install version using asyncio. This requires Python 3.5+:
+```bash
+pip3 install leicacam[asyncio]
 ```
 
 ## Example

--- a/async_client.py
+++ b/async_client.py
@@ -1,0 +1,26 @@
+"""Test client using asyncio."""
+import asyncio
+
+from leicacam.async_cam import AsyncCAM
+
+
+async def run(loop):
+    """Run client."""
+    cam = AsyncCAM(loop=loop)
+    await cam.connect()
+    print(cam.welcome_msg)
+    await cam.send(b'/cmd:deletelist')
+    print(await cam.receive())
+    await cam.send(b'/cmd:deletelist')
+    print(await cam.wait_for(cmd='cmd', timeout=0.1))
+    await cam.send(b'/cmd:deletelist')
+    print(await cam.wait_for(cmd='cmd', timeout=0))
+    print(await cam.wait_for(cmd='cmd', timeout=0.1))
+    print(await cam.wait_for(cmd='test', timeout=0.1))
+    cam.close()
+
+
+if __name__ == '__main__':
+    LOOP = asyncio.new_event_loop()
+    LOOP.run_until_complete(run(LOOP))
+    LOOP.close()

--- a/client.py
+++ b/client.py
@@ -1,0 +1,21 @@
+"""Test client."""
+from time import sleep
+
+from leicacam.cam import CAM
+
+
+def run():
+    """Run client."""
+    cam = CAM()
+    print(cam.welcome_msg)
+    print(cam.send(b'/cmd:deletelist'))
+    sleep(0.1)
+    print(cam.receive())
+    print(cam.send(b'/cmd:deletelist'))
+    sleep(0.1)
+    print(cam.wait_for(cmd='cmd', timeout=0.1))
+    cam.close()
+
+
+if __name__ == '__main__':
+    run()

--- a/leicacam/async_cam.py
+++ b/leicacam/async_cam.py
@@ -1,0 +1,101 @@
+"""Provide an interface using asyncio to the CAM server."""
+import asyncio
+from collections import OrderedDict
+
+from async_timeout import timeout as async_timeout
+
+from leicacam.cam import BaseCAM, _parse_receive, check_messages
+
+
+class AsyncCAM(BaseCAM):
+    """Driver for LASAF Computer Assisted Microscopy using asyncio."""
+
+    def __init__(self, *args, loop=None, **kwargs):
+        """Set up instance."""
+        super().__init__(*args, **kwargs)
+        self.loop = loop or asyncio.get_event_loop()
+        self.reader = None
+        self.writer = None
+        self.welcome_msg = None
+
+    async def connect(self):
+        """Connect to LASAF through a CAM-socket."""
+        self.reader, self.writer = await asyncio.open_connection(
+            self.host, self.port, loop=self.loop)
+        self.welcome_msg = await self.reader.read(self.buffer_size)
+
+    async def send(self, commands):
+        """Send commands to LASAF through CAM-socket.
+
+        Parameters
+        ----------
+        commands : list of tuples or bytes string
+            Commands as a list of tuples or a bytes string. cam.prefix is
+            allways prepended before sending.
+
+        Returns
+        -------
+        int
+            Bytes sent.
+
+        Example
+        -------
+        ::
+
+            >>> # send list of tuples
+            >>> await cam.send([('cmd', 'enableall'), ('value', 'true')])
+
+            >>> # send bytes string
+            >>> await cam.send(b'/cmd:enableall /value:true')
+
+        """
+        msg = self._prepare_send(commands)
+        self.writer.write(msg)
+        await self.writer.drain()
+
+    async def receive(self):
+        """Receive message from socket interface as list of OrderedDict."""
+        try:
+            incomming = await self.reader.read(self.buffer_size)
+        except OSError:
+            return []
+
+        return _parse_receive(incomming)
+
+    async def wait_for(self, cmd, value=None, timeout=60):
+        """Hang until command is received.
+
+        If value is supplied, it will hang until ``cmd:value`` is received.
+
+        Parameters
+        ----------
+        cmd : string
+            Command to wait for in bytestring from microscope CAM interface. If
+            ``value`` is falsey, value of received command does not matter.
+        value : string
+            Wait until ``cmd:value`` is received.
+        timeout : int
+            Minutes to wait for command. If timeout is reached, an empty
+            OrderedDict will be returned.
+
+        Returns
+        -------
+        collections.OrderedDict
+            Last received messsage or empty message if timeout is reached.
+
+        """
+        try:
+            async with async_timeout(timeout * 60):
+                while True:
+                    msgs = await self.receive()
+                    msg = check_messages(msgs, cmd, value=value)
+                    if msg:
+                        return msg
+        except asyncio.TimeoutError:
+            return OrderedDict()
+
+    def close(self):
+        """Close stream."""
+        if self.writer.can_write_eof():
+            self.writer.write_eof()
+        self.writer.close()

--- a/requirements_asyncio.txt
+++ b/requirements_asyncio.txt
@@ -1,0 +1,3 @@
+async_timeout==2.0.1
+asynctest==0.12.2
+pytest-asyncio==0.9.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+-r requirements_asyncio.txt
 -r requirements_pypi.txt
 -r requirements_test.txt
 -r docs/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ setup(
     install_requires=[
         'pydebug'
     ],
+    extras_require={
+        'asyncio':  ['async_timeout'],
+    },
     license='MIT',
     zip_safe=False,
     keywords='leicacam',

--- a/test/test_async_cam.py
+++ b/test/test_async_cam.py
@@ -1,0 +1,116 @@
+"""Tests for async cam module."""
+import pytest
+from asynctest.mock import CoroutineMock, Mock, patch
+
+from leicacam.async_cam import AsyncCAM
+from leicacam.cam import bytes_as_dict, tuples_as_dict
+
+# pylint: disable=redefined-outer-name
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio  # pylint: disable=invalid-name
+
+
+class MockEchoConnection:
+    """Mock an echo connection."""
+
+    msg = b''
+
+    def write(self, msg):
+        """Write a message."""
+        self.msg = msg
+
+    async def read(self, buffer_size):
+        """Read a message."""
+        return self.msg[0:buffer_size]
+
+
+@pytest.fixture
+def mock_connection():
+    """Return an echo connection."""
+    return MockEchoConnection()
+
+
+@pytest.fixture
+def mock_writer(mock_connection):
+    """Mock an asycio connection writer."""
+    writer = Mock()
+    writer.write = mock_connection.write
+    writer.drain = CoroutineMock()
+    writer.wait_closed = CoroutineMock()
+    yield writer
+
+
+@pytest.fixture
+def mock_reader(mock_connection):
+    """Mock an asycio connection reader."""
+    reader = Mock()
+    reader.read = mock_connection.read
+    reader.read_line = CoroutineMock()
+    reader.readexactly = CoroutineMock()
+    reader.readuntil = CoroutineMock()
+    yield reader
+
+
+@pytest.fixture
+def open_connection_ret(mock_reader, mock_writer):
+    """Define the side_effect for open_connection."""
+    return mock_reader, mock_writer
+
+
+@pytest.fixture
+def mock_open_connection(open_connection_ret):
+    """Mock asyncio open_connection."""
+    open_connection_patch = patch(
+        'leicacam.async_cam.asyncio.open_connection',
+        return_value=open_connection_ret)
+    with open_connection_patch as mock_open:
+        yield mock_open
+
+
+@pytest.fixture
+def async_cam(event_loop, mock_open_connection):
+    """Yield an AsyncCAM instance with a mock socket."""
+    # pylint: disable=unused-argument
+    _async_cam = AsyncCAM(loop=event_loop)
+    event_loop.run_until_complete(_async_cam.connect())
+    yield _async_cam
+
+
+async def test_echo(async_cam):
+    """Prefix + command sent should be same as echoed socket message."""
+    cmd = [('cli', 'custom'), ('cmd', 'enableall'), ('value', 'true'),
+           ('integer', 1234), ('float', 0.00234)]
+
+    await async_cam.send(cmd)
+    [response] = await async_cam.receive()
+
+    sent = tuples_as_dict(async_cam.prefix + cmd)
+
+    assert sent == response
+
+
+async def test_send_bytes(async_cam):
+    """Test send a bytes string."""
+    cmd = b'/cmd:enableall /value:true'
+    await async_cam.send(cmd)
+    [response] = await async_cam.receive()
+
+    sent = bytes_as_dict(async_cam.prefix_bytes + cmd)
+
+    assert sent == response
+
+
+async def test_receive_error(async_cam, mock_reader):
+    """Test receive method when a socket error happens."""
+    mock_reader.read = Mock()
+    mock_reader.read.side_effect = OSError()
+    response = await async_cam.receive()
+
+    assert isinstance(response, list)
+    assert not response
+
+
+async def test_close(async_cam, mock_writer):
+    """Test writer close."""
+    async_cam.close()
+    assert mock_writer.close.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = py27, py35, py36, lint
+envlist = py2.7, asyncio, py3.6, lint
 skip_missing_interpreters = True
 
 [travis]
 python =
-  2.7: py27, lint
+  2.7: py27
+  3.5: asyncio, lint
+  3.6: asyncio
 
 [testenv]
 setenv =
@@ -13,10 +15,25 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_test.txt
 commands =
+    pytest --basetemp={envtmpdir} {posargs} test/test_cam.py
+
+[testenv:asyncio]
+basepython = python3
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/leicacam
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements_asyncio.txt
+    -r{toxinidir}/requirements_test.txt
+commands =
     pytest --basetemp={envtmpdir} {posargs}
 
 [testenv:lint]
-basepython = python
+basepython = python3
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements_asyncio.txt
+    -r{toxinidir}/requirements_test.txt
 ignore_errors = True
 commands =
   flake8 leicacam test


### PR DESCRIPTION
* Add driver class using asyncio.
* Add async and sync client example scripts.
* Move convenience methods.
* Fix Python 2 compatability.
* Run lint at Python 3.5 and asyncio imports.
* Add asynctest and pytest-asyncio test requirements.
* Put asyncio requirements in own file.
* Update docstring example.
* Add .coveragerc file.
* Add another test for cam module.
* Add async tests.
* Update tox settings.
* Update requirements dev.
* Update readme.